### PR TITLE
fix typo in the factory

### DIFF
--- a/src/Spryker/Client/ProductStorage/ProductStorageFactory.php
+++ b/src/Spryker/Client/ProductStorage/ProductStorageFactory.php
@@ -109,6 +109,6 @@ class ProductStorageFactory extends AbstractFactory
      */
     public function getProductConcreteRestrictionPlugins(): array
     {
-        return $this->getProvidedDependency(ProductStorageDependencyProvider::PLUGINS_PRODUCT_ABSTRACT_RESTRICTION);
+        return $this->getProvidedDependency(ProductStorageDependencyProvider::PLUGINS_PRODUCT_CONCRETE_RESTRICTION);
     }
 }


### PR DESCRIPTION
I also think that there is a bug in `setAvailableAttributes()` or how its using `findAvailableAttributes()` inside https://github.com/spryker/product-storage/blob/master/src/Spryker/Client/ProductStorage/Mapper/ProductVariantExpander.php 